### PR TITLE
Follow-up for the LUN/LUA core fixes

### DIFF
--- a/HPM/decisions/CleanUp.txt
+++ b/HPM/decisions/CleanUp.txt
@@ -2980,7 +2980,7 @@ political_decisions = {
                             AND = {
                                 is_core = CNG
                                 OR = {
-                                    is_core = LUA
+                                    is_core = LUN
                                     is_core = LOA
                                     is_core = AZA
                                     is_core = KZB
@@ -3224,14 +3224,14 @@ political_decisions = {
                     limit = {
                         is_core = CNG
                         OR = {
-                            is_core = LUA
+                            is_core = LUN
                             is_core = LOA
                             is_core = AZA
                             is_core = KZB
                             is_core = KON
                         }
                     }
-                    remove_core = LUA
+                    remove_core = LUN
                     remove_core = LOA
                     remove_core = AZA
                     remove_core = KZB

--- a/HPM/events/GreatWar_Events.txt
+++ b/HPM/events/GreatWar_Events.txt
@@ -11664,7 +11664,7 @@ country_event = {
             any_owned = {
                 limit = { is_core = CNG }
                 remove_core = CGO
-                remove_core = LUA
+                remove_core = LUN
                 remove_core = LOA
                 remove_core = AZA
                 remove_core = KZB
@@ -11682,7 +11682,7 @@ country_event = {
             any_owned = {
                 limit = { is_core = ZAM }
                 remove_core = KZB
-                remove_core = LUA
+                remove_core = LUN
                 secede_province = THIS
             }
         }


### PR DESCRIPTION
This is a follow-up to:

> * Fixes for LUN/LUA core removals in Congo.

which was a part of 8eb31840d3b738d690de61bc316cea16279db383.

Just like it, this corrects `LUA` (Luang Prabang) core removals to `LUN`
(Lunda) when they concern the Congo/Zambia part of the world. A review
of all `LUA` occurrences suggest that all remaining mentions really do
concern Luang Prabang now.