### PR TITLE
Restrict Eiffel Tower World Fair exploit

### DIFF
--- a/HPM/decisions/France.txt
+++ b/HPM/decisions/France.txt
@@ -287,8 +287,6 @@ political_decisions = {
             NOT = {
                 has_country_flag = the_eiffel_tower_was_built
             }
-
-            has_country_flag = world_fair_planner
         }
 
         allow = {

--- a/HPM/events/WorldFairs.txt
+++ b/HPM/events/WorldFairs.txt
@@ -28,8 +28,7 @@ country_event = {
         modifier = {
             factor = 0.01
             tag = FRA
-            invention = bessemer_steel
-            NOT = { has_country_flag = the_eiffel_tower_was_built }
+            has_country_modifer = eiffel_tower_construction
         }
 
         modifier = {


### PR DESCRIPTION
France gets a vastly increased priority to be offered the chance to host
the next World Fair, but only so long as the Eiffel Tower hasn't been
built. This leads to an exploit where a crafty player never does build
it, to keep open the option to convert cash into prestige.

This change flips cause and effect around: France needs to have started
construction of the Eiffel Tower around, before being considered for
increased priority. Construction is still conditioned on
`bessemer_steel`, same as before.